### PR TITLE
Fixing lever input bug for level 1 room 1

### DIFF
--- a/Cosmic Quest - Order and Chaos/Assets/Collections/MK Glow/MKGlow/Scripts/LWRP.meta
+++ b/Cosmic Quest - Order and Chaos/Assets/Collections/MK Glow/MKGlow/Scripts/LWRP.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f303c366664628b43a4e5aa5c94d2fce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cosmic Quest - Order and Chaos/Assets/Scripts/World/PuzzleRoom.cs
+++ b/Cosmic Quest - Order and Chaos/Assets/Scripts/World/PuzzleRoom.cs
@@ -21,21 +21,23 @@ public class PuzzleRoom : Lvl1
     /// <returns>A boolean indicating whether all levers in the room have been pulled in correct pattern or not</returns>
     public override bool AreLeversPulled()
     {
-        // Clear input on failed tries
-        if (Input.Count > Code.Count) Input.Clear();
+        bool isCorrectPattern = true;
 
         // If input count hasn't reached code count, return false
         if (Input.Count != Code.Count) {
-            return false;
+            isCorrectPattern = false;
         }
 
         for (int i = 0; i < Input.Count; i++)
         {
             if (Input[i] != Code[i]) {
-                return false;
+                isCorrectPattern = false;
             }
         }
+        
+        // Reset if code input maxed out
+        if (Input.Count >= Code.Count) Input.Clear();
 
-        return true;
+        return isCorrectPattern;
     }   
 }


### PR DESCRIPTION
Fixes bug concerning lever code input not being reset correctly after a failed attempt by simply moving input clearing to the end of the function.