### PR TITLE
Smartmerge

### DIFF
--- a/Cosmic Quest - Order and Chaos/.gitattributes
+++ b/Cosmic Quest - Order and Chaos/.gitattributes
@@ -1,3 +1,8 @@
+# Treat unity files as binary
+*.unity binary
+*.prefab binary
+*.asset binary
+
 # 3D models
 *.3dm filter=lfs diff=lfs merge=lfs -text
 *.3ds filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ One of the main areas for merge conflicts is in files using Unity's YAML format 
 ```
 
 Replace `<path to UnityYAMLMerge.exe>` with the appropriate path to this tool. The path will look something like this: `'<Unity install directory>\\Editor\\Data\\Tools\\UnityYAMLMerge.exe'` (Remember to escape the backslashes on windows, as seen in the example).
+
+#### Using SmartMerge to resolve merge conflicts
+
+When you have merge conflicts including Unity files (`*.unity`, `*.prefab`, `*.asset`), be sure to first resolve any merge conflicts in any other files such as any `*.cs` files (mergetool can't handle these files and will throw a warning). Once these conflicts are figured out, run the command `git mergetool` and SmartMerge will smoothly handle merging the Unity objects. It will ask you if the merge was successful (a chance for you to check quickly that things look alright), then after it finishes it will create backups with the file ending `*.orig` (if you could remove those before committing that would be great). Once all the merging is sorted out, then run `git add .` to add all of the new changes, then finally `git merge --continue` to complete the merge.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ $ git push origin my-branch
 # Pull the latest changes from master to your branch (may cause merge issues)
 $ git pull origin master
 ```
+
+### Setting up Unity's SmartMerge
+
+One of the main areas for merge conflicts is in files using Unity's YAML format (i.e. Prefabs, scenes, etc.). However, Unity provides a tool that can merge these files from a content-area perspective. The repo is setup to use this tool for merging these files, however you do need to *manually set up the git config so git knows where this tool is*. To do so, simply append the following to `.git/config`:
+
+```
+[merge]
+    tool = unityyamlmerge
+[mergetool "unityyamlmerge"]
+    trustExitCode = false
+    cmd = <path to UnityYAMLMerge.exe> merge -p "$BASE" "$REMOTE" "$LOCAL" "$MERGED"
+```
+
+Replace `<path to UnityYAMLMerge.exe>` with the appropriate path to this tool. The path will look something like this: `'<Unity install directory>\\Editor\\Data\\Tools\\UnityYAMLMerge.exe'` (Remember to escape the backslashes on windows, as seen in the example).


### PR DESCRIPTION
This contains the base changes and instructions on how to setup and use Unity's SmartMerge tool, which will allow us to nicely merge conflicting scene/prefab/asset changes. The information on setting up is outlined in the [README](https://github.com/olejarza/VACATe/blob/smartmerge/README.md), as well as its general workflow which is something like this:

``` bash
$ git merge origin/master
MERGE CONFLICTS
  testScene.unity
  example.cs

# Fix merge problems with code files first, then add those changes
$ git add example.cs

# Run this command to automatically fix the Unity file merge issues
$ git mergetool

# If all is good, then complete the merge process
$ git add .
$ git merge --continue
```

If you have any problems with the set up or any other questions then feel free to ask me.